### PR TITLE
[FIX] White MATE logo for dark theme

### DIFF
--- a/matefaenzadark/index.theme
+++ b/matefaenzadark/index.theme
@@ -2,7 +2,7 @@
 Name=MATE-Faenza-Dark
 Inherits=matefaenza
 Comment=Icon theme project with tilish style, by Tiheum
-Directories=actions/16,apps/16,categories/16,status/16,stock/16,actions/22,apps/22,categories/22,status/22,stock/22,actions/24,apps/24,categories/24,status/24,stock/24,actions/32,apps/32,categories/32,status/32,stock/32,actions/48,apps/48,categories/48,status/48,stock/48,actions/64,apps/64,categories/64,status/64,stock/64,actions/96,apps/96,categories/96,status/96,stock/96,actions/scalable,apps/scalable,categories/scalable,status/scalable,stock/scalable
+Directories=actions/16,apps/16,categories/16,status/16,stock/16,actions/22,apps/22,categories/22,status/22,stock/22,places/22,actions/24,apps/24,categories/24,status/24,stock/24,places/24,actions/32,apps/32,categories/32,status/32,stock/32,actions/48,apps/48,categories/48,status/48,stock/48,actions/64,apps/64,categories/64,status/64,stock/64,actions/96,apps/96,categories/96,status/96,stock/96,actions/scalable,apps/scalable,categories/scalable,status/scalable,stock/scalable
 
 [actions/16]
 Size=16
@@ -54,6 +54,11 @@ Size=22
 Context=Stock
 Type=fixed
 
+[places/22]
+Size=22
+Context=Places
+Type=fixed
+
 [actions/24]
 Size=24
 Context=Actions
@@ -77,6 +82,11 @@ Type=fixed
 [stock/24]
 Size=24
 Context=Stock
+Type=fixed
+
+[places/24]
+Size=24
+Context=Places
 Type=fixed
 
 [actions/32]


### PR DESCRIPTION
When using the MATE Faenze Dark Icon theme, the MATE logo next to the Applications menu is from matefaenza/places/start-here.png, which is a dark grey and not suited for a dark theme. This fix should now replace it with the white MATE logo found in the matefaezadark/places/start-here.png, which is more suitable for a dark theme. The fix involves adding the places/22 and places/24 directories into the index.theme file.